### PR TITLE
Provide ansible in debian 9 container

### DIFF
--- a/Dockerfile-debian9
+++ b/Dockerfile-debian9
@@ -1,0 +1,7 @@
+FROM debian:9
+
+RUN apt-get update && apt-get install -y python-pip git
+RUN pip install ansible
+
+# default command: display Ansible version
+CMD [ "ansible-playbook", "--version" ]


### PR DESCRIPTION
* will be autobuilt on hub.docker.com
* will yield in tagged image `simplificator/ansible:debian9`