### PR TITLE
Install nodeping API module

### DIFF
--- a/alpine3/Dockerfile
+++ b/alpine3/Dockerfile
@@ -3,14 +3,18 @@ FROM python:3.8-alpine
 
 RUN echo "===> Adding Ansible dependencies..."  && \
 	apk --update add git bash openssh && \
-    apk --update add --virtual build-dependencies libffi-dev openssl-dev build-base && \
-    pip install --upgrade pip pycrypto cffi jmespath && \
+    apk --update add --virtual build-dependencies libffi-dev openssl-dev build-base wget && \
+    pip install --upgrade pip pycrypto cffi jmespath nodeping-api && \
     \
     echo "===> Installing Ansible..."  && \
     pip install ansible=='2.9.9' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing package list..."  && \
-    apk del build-dependencies libffi-dev openssl-dev build-base && \
+    apk del build-dependencies libffi-dev openssl-dev build-base wget && \
     rm -rf /var/cache/apk/*               && \
     \
     echo "===> Adding hosts for convenience..."  && \

--- a/alpine3/Dockerfile
+++ b/alpine3/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "===> Adding Ansible dependencies..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing package list..."  && \
     apk del build-dependencies libffi-dev openssl-dev build-base wget && \

--- a/debian10-windows-deploy/Dockerfile
+++ b/debian10-windows-deploy/Dockerfile
@@ -6,16 +6,20 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
     apt-get install -y python3 python3-pip python3-dev \
-    gcc git libffi-dev libssl-dev ssh && \
-    pip3 install --upgrade pycrypto cffi jmespath && \
+    gcc git libffi-dev libssl-dev ssh wget && \
+    pip3 install --upgrade pycrypto cffi jmespath nodeping-api && \
     \
     echo "===> Installing Ansible & PyWinRM..."   && \
     pip3 install ansible=='2.9.9' && \
     pip3 install pywinrm[credssp]=='0.4.1' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \
-    gcc libffi-dev libssl-dev python3-dev && \
+    gcc libffi-dev libssl-dev python3-dev wget && \
     apt-get clean                                                 && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
     \

--- a/debian10-windows-deploy/Dockerfile
+++ b/debian10-windows-deploy/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \

--- a/debian10/Dockerfile
+++ b/debian10/Dockerfile
@@ -6,15 +6,19 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
     apt-get install -y python3 python3-pip python3-dev python3-apt \
-    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg && \
-    pip3 install --upgrade pycrypto cffi jmespath jmespath && \
+    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg wget && \
+    pip3 install --upgrade pycrypto cffi jmespath jmespath nodeping-api && \
     \
     echo "===> Installing Ansible..."   && \
     pip3 install ansible=='2.9.9' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \
-    gcc libffi-dev libssl-dev python3-dev && \
+    gcc libffi-dev libssl-dev python3-dev wget && \
     apt-get clean                                                 && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
     \

--- a/debian10/Dockerfile
+++ b/debian10/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -5,15 +5,19 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
     apt-get install -y python python-pip python-dev python-apt \
-    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg && \
-    pip install --upgrade pycrypto cffi jmespath && \
+    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg wget && \
+    pip install --upgrade pycrypto cffi jmespath nodeping-api && \
     \
     echo "===> Installing Ansible..."   && \
     pip install ansible=='2.9.9' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \
-    gcc libffi-dev libssl-dev python-dev && \
+    gcc libffi-dev libssl-dev python-dev wget && \
     apt-get clean                                                 && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
     \

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -5,15 +5,19 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
     apt-get install -y python3 python3-pip python3-dev python3-apt \
-    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg && \
-    pip3 install --upgrade pycrypto cffi jmespath && \
+    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg wget && \
+    pip3 install --upgrade pycrypto cffi jmespath nodeping-api && \
     \
     echo "===> Installing Ansible..."   && \
     pip3 install ansible=='2.9.9' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \
-    gcc libffi-dev libssl-dev python3-dev && \
+    gcc libffi-dev libssl-dev python3-dev wget && \
     apt-get clean                                                 && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
     \

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \

--- a/ubuntu1804/Dockerfile
+++ b/ubuntu1804/Dockerfile
@@ -5,15 +5,19 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
     apt-get install -y python3 python3-pip python3-dev \
-    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg && \
-    pip3 install --upgrade pycrypto cffi jmespath && \
+    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg wget && \
+    pip3 install --upgrade pycrypto cffi jmespath nodeping-api && \
     \
     echo "===> Installing Ansible..."   && \
     pip3 install ansible=='2.9.9' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \
-    gcc libffi-dev libssl-dev python3-dev && \
+    gcc libffi-dev libssl-dev python3-dev wget && \
     apt-get clean                                                 && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
     \

--- a/ubuntu1804/Dockerfile
+++ b/ubuntu1804/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -5,15 +5,19 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     apt-get update -y  &&  apt-get install --fix-missing          && \
     DEBIAN_FRONTEND=noninteractive         \
     apt-get install -y python3 python3-pip python3-dev \
-    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg && \
-    pip3 install --upgrade pycrypto cffi jmespath && \
+    curl gcc git libffi-dev libssl-dev libapt-pkg-dev git ssh gnupg wget && \
+    pip3 install --upgrade pycrypto cffi jmespath nodeping-api && \
     \
     echo "===> Installing Ansible..."   && \
     pip3 install ansible=='2.9.9' && \
     \
+    echo "===> Installing Nodeping module ..."  && \
+    mkdir -p ~/.ansible/plugins/modules/ && \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \
-    gcc libffi-dev libssl-dev python3-dev && \
+    gcc libffi-dev libssl-dev python3-dev wget && \
     apt-get clean                                                 && \
     rm -rf /var/lib/apt/lists/*  /tmp/*                           && \
     \

--- a/ubuntu2004/Dockerfile
+++ b/ubuntu2004/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "===> Installing dev libraries and supporting tools ..."  && \
     \
     echo "===> Installing Nodeping module ..."  && \
     mkdir -p ~/.ansible/plugins/modules/ && \
-    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/master/nodeping.py &&  \
+    wget -P ~/.ansible/plugins/modules https://raw.githubusercontent.com/NodePing/nodeping-ansible/ad1cefa077e6c7c18dc5bdaaa12e51e9584febb1/nodeping.py &&  \
     \
     echo "===> Removing unused APT resources..."                  && \
     apt-get -f -y --auto-remove remove \


### PR DESCRIPTION
This PR adds the Nodeping API module to this container. This enables modifications of contacts, checks etc. via Ansible.

Sadly, the Nodeping module only has a master branch and no version tags, so we always fetch the latest version.